### PR TITLE
Refactor bot joining logic and improve threading

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,14 +1,15 @@
 import string, random, os, time, threading
 from kahoot import client
 
-bot = client()
-
 class KahootSpammer:
     def __init__(self):
         print('KahootTools - Remastered by Nightmrs - Originally made by xeny')
         self.gamepin = input('PIN: ')
         self.botamount = input('Amount of bots (max 2000): ')
         self.custom_user = input('Enter desired username (5 or less chars) (leave blank if none): ')
+        self.successful_joins = 0
+        self.failed_joins = 0
+        self.lock = threading.Lock()
 
     def joinHandle(self):
         pass
@@ -17,16 +18,48 @@ class KahootSpammer:
         return ''.join(random.choice(string.ascii_letters) for _ in range(integer))
 
     def joingame(self):
+        # Generate bot username
         if self.custom_user == "":
             self.username = ('xeny ' + '| ' + self.randName(6))
         else:
             self.username = (self.custom_user + ' | ' + self.randName(6))
 
-        bot.join(self.gamepin, self.username)
-        bot.on("joined", self.joinHandle)
-        print(f"Joined game {self.gamepin} with username {self.username}.")
+        # Create a new client instance for each bot
+        bot = client()
+        
+        try:
+            bot.join(self.gamepin, self.username)
+            bot.on("joined", self.joinHandle)
+            
+            with self.lock:
+                self.successful_joins += 1
+                print(f"[{self.successful_joins}/{self.botamount}] Joined with username: {self.username}")
+                
+        except Exception as e:
+            with self.lock:
+                self.failed_joins += 1
+                print(f"Failed to join with {self.username}: {e}")
+
+        # Small delay to prevent rate limiting
+        time.sleep(0.1)
 
 if __name__ == '__main__':
     Client = KahootSpammer()
+    
+    print(f"\nStarting {Client.botamount} bots...")
+    print("-" * 40)
+    
+    threads = []
     for x in range(int(Client.botamount)):
-       threading.Thread(target=Client.joingame()).start()
+        # Fixed: Pass the method reference, not the result
+        thread = threading.Thread(target=Client.joingame)
+        threads.append(thread)
+        thread.start()
+        time.sleep(0.05)  # Stagger thread starts
+    
+    # Wait for all threads to complete
+    for thread in threads:
+        thread.join()
+    
+    print("-" * 40)
+    print(f"Finished! Successfully joined: {Client.successful_joins}, Failed: {Client.failed_joins}")


### PR DESCRIPTION
## Pull Request

### Description
Fixed critical threading bug where bots weren't actually spawning properly, plus added basic error handling and tracking.

### Changes
- Fixed `threading.Thread(target=Client.joingame())` to `threading.Thread(target=Client.joingame)` so method is passed as reference instead of being called immediately
- Moved `bot = client()` inside `joingame()` so each thread gets its own client instance
- Added try/except block around join attempts to handle failures gracefully
- Added threading.Lock() for thread-safe counters and prints
- Added successful/failed join counters with progress output
- Added small delays between thread starts and join attempts to prevent rate limiting
- Added completion summary showing total successful and failed joins
- Threads now stored in list and joined properly at end

### Why
Original code had two major issues: thread target was being called instantly instead of in the thread, and all bots shared one client causing conflicts. Now it actually works.